### PR TITLE
Firefox bug fix

### DIFF
--- a/store.js
+++ b/store.js
@@ -50,15 +50,13 @@ var store = (function(){
 	// when about.config::dom.storage.enabled === false
 	// See https://github.com/marcuswestin/store.js/issues#issue/13
 	function isLocalStorageNameSupported() {
-		var ret = false;
-		try { ret = (localStorageName in win && win[localStorageName]) }
-		finally { return ret }
+		try { return (localStorageName in win && win[localStorageName]) }
+		catch(err) { return false }
 	}
 	
 	function isGlobalStorageNameSupported() {
-		var ret = false;
-		try { ret = (globalStorageName in win && win[globalStorageName] && win[globalStorageName][win.location.hostname]) }
-		finally { return ret }
+		try { return (globalStorageName in win && win[globalStorageName] && win[globalStorageName][win.location.hostname]) }
+		catch(err) { return false }
 	}	
 
 	if (isLocalStorageNameSupported()) {


### PR DESCRIPTION
Hey Marcus, here's the pull request introducing try...finally into the testing for storage mechanisms to not crash Firefox when about.config::dom.storage.enabled === false. 

Note that if about.config::dom.storage.enabled === false then many of the unit tests fail outright.

One could make the case that this is, in fact, correct behavior if the browser is so-configured.

I'm wondering if store.js could resort to other storage strategies if about.config::dom.storage.enabled === false.
