### PR TITLE
Fixed bug when saving 'undefined' values

### DIFF
--- a/store.js
+++ b/store.js
@@ -63,7 +63,12 @@ var store = (function(){
 
 	if (isLocalStorageNameSupported()) {
 		storage = win[localStorageName]
-		api.set = function(key, val) { storage.setItem(key, api.serialize(val)) }
+		api.set = function(key, val) { 
+			if (typeof val === "undefined" || val === null)
+				api.remove(key)
+			else
+				storage.setItem(key, api.serialize(val)) 			
+		}
 		api.get = function(key) { return api.deserialize(storage.getItem(key)) }
 		api.remove = function(key) { storage.removeItem(key) }
 		api.clear = function() { storage.clear() }


### PR DESCRIPTION
If you save `undefined` value with store.js, you'll get error while getting it. 
It's pretty easy to reproduce: http://jsfiddle.net/8w6qT/2

``` javascript
store.set('prop', undefined);
store.get('prop');
-> Uncaught SyntaxError: Unexpected token u
```

JSON can't parse "undefined" string

This bug caused by browser localStorage implementation (tested in Chrome and Firefox):

``` javascript
localStorage.setItem('prop', undefined);
localStorage.getItem('prop');
-> "undefined"
```

localStorage store undefined values as strings

This patch fix it. http://jsfiddle.net/8w6qT/3
