### PR TITLE
Updated docs to reflect removal of same-path limitation in IE6/7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,6 @@ store.js exposes a simple API for cross browser local storage
 
 store.js depends on JSON for serialization.
 
-IE6/7 limitation
-----------------
-Access to the userData behavior in IE6 and IE7 is restricted to "same directory" in the path of the URL, much like access to localStorage is restricted to "same domain" in the protocol and host name of the URL. In addition, just as localStorage cannot be accessed across sub domains, userData behavior cannot be accessed across sub-directories.
-
-Here are some examples to demonstrate the IE6 and IE7 limitations:
-
-	// on http://example.com/path1/
-	store.set('foo', 1)
-	
-	// on http://example.com/path1/test.html the value of "foo"
-	// is readable because we are in the same "directory" /path1/
-	store.get('foo') == 1
-	store.set('bar', 2)
-	
-	// on http://example.com/path2/ the values of "foo" and "bar" are not readable
-	// because we are not in the same "directory" - the directory is not /path2/
-	store.get('foo') == null
-	store.get('bar') == null
-
-	// on http://example.com/path1/subpath/ the values of "foo" and "bar" are not
-	// readable here either, because we are in the directory /path1/subpath/.
-	store.get('foo') == null
-	store.get('bar') == null
-
 How does it work?
 ------------------
 store.js uses localStorage when available, and falls back on globalStorage for earlier versions of Firefox and the userData behavior in IE6 and IE7. No flash to slow down your page load. No cookies to fatten your network requests.
@@ -103,8 +79,8 @@ Supported browsers
  - Tested in Chrome 11
  - Tested in Safari 4
  - Tested in Safari 5
- - Tested in IE6
- - Tested in IE7
+ - Tested in IE6 (limited to 1MB)
+ - Tested in IE7 (limited to 1MB)
  - Tested in IE8
  - Tested in Opera 10
    - Opera 10.54


### PR DESCRIPTION
Just did a test this morning, and (assuming I was checking correctly) it appears that setting `document.domain` does not cause any errors in the [patch](https://github.com/mjpizz/store.js/commit/bfe3805815f394734dd7852b258d92146e048b8d) from yesterday.  Good eye asking about that :)

So here are the updated docs without mention of IE6/7 same-path restrictions, though I did add that IE6/7 userData is limited to [1MB in size](http://www.javascriptkit.com/javatutors/domstorage2.shtml).
