### PR TITLE
Fix syntax error in README storeWithExpiration demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ var storeWithExpiration = {
 	}
 }
 storeWithExpiration.set('foo', 'bar', 1000)
-setTimeout(function() { console.log(storeWithExpiration.get('foo') }, 500) // -> "bar"
-setTimeout(function() { console.log(storeWithExpiration.get('foo') }, 1500) // -> null
+setTimeout(function() { console.log(storeWithExpiration.get('foo')) }, 500) // -> "bar"
+setTimeout(function() { console.log(storeWithExpiration.get('foo')) }, 1500) // -> null
 ```
 
 Tests


### PR DESCRIPTION
There's a syntax error in the demo for the storeWithExpiration function demo.
