### PR TITLE
Rename component.json to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name" : "store",
-  "version" : "1.3.9",
+  "version" : "1.3.10",
   "description" : "a simple API for cross browser local storage",
   "main" : "store.js",
   "scripts" : [ "store.js" ]


### PR DESCRIPTION
I got a warning when installing via bower:

```
bower warn Package store.js is still using the deprecated "component.json" file
bower copying /Users/vincentmac/.bower/cache/store.js/2eac468840286756b7ac04cbe683f402
mismatch The version specified in the component.json of package store.js mismatches the tag (1.3.9 vs 1.3.8)
mismatch You should report this problem to the package author
bower installing store#1.3.9
```
### Actions taken
- Renamed component.json to bower.json
- Bumped version to v1.3.10 and tagged head (you may have to retag on your end).
