### PR TITLE
Adds the MIT licence header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2010-2013 Marcus Westin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
For whom licences are important is reassuring to see the MIT licence header. That way it perfectly follows the one at http://opensource.org/licenses/MIT
