### PR TITLE
Avoid warning from npm about invalid filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
   "devDependencies": {
     "uglify-js": "v1.3.4"
   },
-  "files": [
-    ""
-  ],
   "spm": {
     "main": "store.js"
   }


### PR DESCRIPTION
With `"files": [""]` npm@1.4.9 complains about an invalid filename:

```
npm WARN package.json store@1.3.16 Invalid filename in 'files' list:
```
