### PR TITLE
Infinite loop in IE

### DIFF
--- a/store.js
+++ b/store.js
@@ -156,10 +156,8 @@
 		})
 		store.clear = withIEStorage(function(storage) {
 			var attributes = storage.XMLDocument.documentElement.attributes
-			storage.load(localStorageName)
-			while (attributes.length) {
+			while (attributes.length)
 				storage.removeAttribute(attributes[0].name)
-			}
 			storage.save(localStorageName)
 		})
 		store.getAll = function(storage) {


### PR DESCRIPTION
Infinite loop in IE9- in ```store.clear``` method. There is no need to call ```storage.load(localStorageName)``` in ```store.clear``` twise which causes an infinite loop. The solution is to remove ```storage.load(localStorageName)``` line.