### PR TITLE
Add correct bower.io name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name" : "store",
+  "name" : "store-js",
   "version" : "1.3.17",
   "description" : "a simple API for cross browser local storage",
   "main" : "store.js",


### PR DESCRIPTION
Add this patch to avoid the downloads of the wrong package (`store`).