### PR TITLE
fix `has` in browsers that have `localStorage`

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -64,6 +64,9 @@ module.exports = (function() {
 			var val = store.deserialize(storage.getItem(key))
 			return (val === undefined ? defaultVal : val)
 		}
+		store.has = function(key) {
+			return Object.prototype.hasOwnProperty.call(storage, key);
+		}
 		store.remove = function(key) { storage.removeItem(key) }
 		store.clear = function() { storage.clear() }
 		store.forEach = function(callback) {


### PR DESCRIPTION
BEFORE:

``` js
>> store.has('asdf');
false
>> store.set('asdf', undefined);
undefined
>> store.has('asdf');
false
```

AFTER:

``` js
>> store.has('asdf');
false
>> store.set('asdf', undefined);
undefined
>> store.has('asdf');
true
```
