### PR TITLE
Remove invalid engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "uglifyify": "^3.0.1"
   },
   "engines": {
-    "browser": "*",
     "node": "*"
   },
   "directories": {


### PR DESCRIPTION
Based on yarn install this `browser` is an invalid engine.
```
$ yarn add jquery@1.11.3
yarn add v0.16.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning store@1.3.20: The engine "browser" appears to be invalid.
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
success Saved lockfile.
success Saved 82 new dependencies.
```