### PR TITLE
Storages limits table

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,24 @@ Store.js will pick the best available storage, and automatically falls back to t
 - [oldIE-userDataStorage.js](storages/oldIE-userDataStorage.js) Store values in userData. Only useful for legacy IE 6+.
 
 
+### Storages limits
+
+|                 | Chrome 40+ | Firefox 34+ | Safari 6+ |   IE 9+  | Mobile Chrome 40+ | Safari (mobile) 6+ | Android Browser |
+|:---------------:|:----------:|:-----------:|:---------:|:--------:|:-----------------:|:------------------:|:---------------:|
+|     Cookies*    |    ~4KB    |     ~4KB    |    ~4KB   |   ~4KB   |        ~4KB       |        ~4KB        |       ~4KB      |
+|   localStorage  |    10MB    |     10MB    |    5MB    |   10MB   |        10MB       |         5MB        |     2.5MB***    |
+|  sessionStorage |    10MB    |     10MB    | Unlimited |   10MB   |        10MB       |         5MB        |      5MB***     |
+|  Browser cache  |  RAM size  |   RAM size  |  RAM size | RAM size |      RAM size     |      RAM size      |     RAM size    |
+| globalStorage** |            |     5MB     |           |          |                   |                    |                 |
+|    userData**   |            |             |           |  1024KB  |                   |                    |                 |
+
+*Cookies numbers, max size per cookie/domain vary in different browsers and versions. [Check out here for me](http://browsercookielimits.squawky.net/) 
+
+**globalStorage and userData Behaviour are used in version 6 and 7 of (respectively) Firefox and Internet Explorer, where localStorage is not available.
+
+***Session and Local storage limits in Android Browser are different for each version. Check out [more here](http://dev-test.nemikor.com/web-storage/support-test/)
+
+
 ### Write your own Storage
 
 Chances are you won't ever need another storage. But if you do...

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Store.js
 6. [Storages](#user-content-storages)
 	- Storages provide underlying persistence
 	- [List of all Storages](#user-content-list-of-all-storages)
+	- [Storages limits](#user-content-storages-limits)
 	- [Write your own Storage](#user-content-write-your-own-storage)
 
 
@@ -237,11 +238,11 @@ Store.js will pick the best available storage, and automatically falls back to t
 | globalStorage** |            |     5MB     |           |          |                   |                    |                 |
 |    userData**   |            |             |           |  1024KB  |                   |                    |                 |
 
-*Cookies numbers, max size per cookie/domain vary in different browsers and versions. [Check out here for me](http://browsercookielimits.squawky.net/) 
+*Cookies numbers, max size per cookie/domain vary in different browsers and versions. [Check out here for more.](http://browsercookielimits.squawky.net/) 
 
 **globalStorage and userData Behaviour are used in version 6 and 7 of (respectively) Firefox and Internet Explorer, where localStorage is not available.
 
-***Session and Local storage limits in Android Browser are different for each version. Check out [more here](http://dev-test.nemikor.com/web-storage/support-test/)
+***Session and Local storage limits in Android Browser are different for each version. [Check out here for more.](http://dev-test.nemikor.com/web-storage/support-test/)
 
 
 ### Write your own Storage


### PR DESCRIPTION
This subject is wider than I thought! 
I have tested these numbers with latest Chrome, chrome on mobile and firefox. Couldn't check in IE or Safari (as I have no access to those), so I just used numbers [from here](https://www.html5rocks.com/en/tutorials/offline/quota-research/#toc-overview).

I've put a "~" sign next to Cookie size, as its variations is almost different in every browser/version. Added link to an article that can be helpful.

About Browser memory - [from this disscussion](https://groups.google.com/forum/#!topic/comp.lang.javascript/332YSnPsw_w/discussion) I assume that we are limited (limited?) to PC's RAM. Although I could be wrong here.

I'd be glad to hear any feedback/thoughts on this.

Thanks

