### PR TITLE
Allow super_fn argument passing from mixins

### DIFF
--- a/src/store-engine.js
+++ b/src/store-engine.js
@@ -171,7 +171,11 @@ function createStore(storages, plugins) {
 				// this mixin.
 				function super_fn() {
 					if (!oldFn) { return }
-					var result = oldFn.apply(self, super_fn.args)
+					var args = Array.prototype.slice.call(arguments)
+					super_fn.args.forEach(function (arg, i) {
+						args[i] = (args[i] === undefined) ? arg : args[i]
+					})
+					var result = oldFn.apply(self, args)
 					delete super_fn.args
 					return result
 				}


### PR DESCRIPTION
When a mixin calls `super_fn`, the arguments are currently bound to the original call, which makes it impossible to do some more advanced things, like override `set` for example.

```js
function compressionPlugin() {
  return {
    set: set
  }

  function set(super_fn, key, value) {
    var newValue = 'MODIFIED' + value;
    super_fn(key, newValue)
  }
}
```

As a plugin author, you may expect that calling `set('foo', 'bar')` results in `MODIFIEDbar` being stored. But because the original args value, `bar`, is bound, that's the value that gets stored.

With this PR, any arguments passed into `super_fn` override the original values, so calling `set('foo', 'bar')` with this PR results in `MODIFIEDbar` being stored.

Additionally, any additional arguments passed in the original call will continue to be passed through unmodified.

I'm not entirely sure how to write tests for this change, short of writing a plugin that would use this change. That said, I would like to modify #204 to use it...