### PR TITLE
Add command for new release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+message = 'v%s'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A localStorage wrapper for all browsers without using cookies or flash. Uses localStorage, globalStorage, and userData behavior under the hood",
   "main": "dist/store.legacy.js",
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "preversion": "bash scripts/release-prompt.sh",
+    "version": "make build && git add -A dist",
+    "postversion": "git push && git push --tags"
   },
   "repository": {
     "type": "git",

--- a/scripts/release-prompt.sh
+++ b/scripts/release-prompt.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+read -p "Are you sure you want to upgrade to v$npm_package_version? Type '$npm_package_version' to continue: "
+[[ $REPLY == $npm_package_version ]]

--- a/src/store-engine.js
+++ b/src/store-engine.js
@@ -12,9 +12,9 @@ module.exports = {
 }
 
 var storeAPI = {
-	version: '2.0.3',
+	version: require('../package.json').version,
 	enabled: false,
-	
+
 	// addStorage adds another storage to this store. The store
 	// will use the first storage it receives that is enabled, so
 	// call addStorage in the order of preferred storage.


### PR DESCRIPTION
Here's a first stab at #199 using `npm version`. Wasn’t sure if I should add a command to the Makefile or if running `npm version patch/minor/major && npm publish` was good enough (since passing the patch/minor/major arg to a make command is a bit of a pain). I also updated `store-engine.js` to import the version string from `package.json`, but if there’s a good reason for keeping it in two places I’m happy to retool my PR a bit!