### PR TITLE
Remove trailing commas in objects literals

### DIFF
--- a/src/store-engine.js
+++ b/src/store-engine.js
@@ -8,7 +8,7 @@ var isFunction = util.isFunction
 var isObject = util.isObject
 
 module.exports = {
-	createStore: createStore,
+	createStore: createStore
 }
 
 var storeAPI = {
@@ -128,7 +128,7 @@ var storeAPI = {
 	// and applies the the given mixins to the instance.
 	createStore: function(storages, plugins) {
 		return createStore(storages, plugins)
-	},
+	}
 }
 
 function createStore(storages, plugins) {
@@ -200,7 +200,7 @@ function createStore(storages, plugins) {
 			catch(e) { val = strVal }
 
 			return (val !== undefined ? val : defaultVal)
-		},
+		}
 	}
 
 	var store = create(_privateStoreProps, storeAPI)

--- a/src/util.js
+++ b/src/util.js
@@ -15,7 +15,7 @@ module.exports = {
 	isList: isList,
 	isFunction: isFunction,
 	isObject: isObject,
-	Global: Global,
+	Global: Global
 }
 
 function make_assign() {

--- a/storages/all.js
+++ b/storages/all.js
@@ -5,5 +5,5 @@ module.exports = {
 	'oldIE-userDataStorage': require('./oldIE-userDataStorage'),
 	'cookieStorage': require('./cookieStorage'),
 	'sessionStorage': require('./sessionStorage'),
-	'memoryStorage': require('./memoryStorage'),
+	'memoryStorage': require('./memoryStorage')
 }

--- a/storages/cookieStorage.js
+++ b/storages/cookieStorage.js
@@ -12,7 +12,7 @@ module.exports = {
 	write: write,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 var doc = Global.document

--- a/storages/localStorage.js
+++ b/storages/localStorage.js
@@ -7,7 +7,7 @@ module.exports = {
 	write: write,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 function localStorage() {

--- a/storages/memoryStorage.js
+++ b/storages/memoryStorage.js
@@ -9,7 +9,7 @@ module.exports = {
 	write: write,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 var memoryStorage = {}

--- a/storages/oldFF-globalStorage.js
+++ b/storages/oldFF-globalStorage.js
@@ -11,7 +11,7 @@ module.exports = {
 	write: write,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 var globalStorage = Global.globalStorage

--- a/storages/oldIE-userDataStorage.js
+++ b/storages/oldIE-userDataStorage.js
@@ -11,7 +11,7 @@ module.exports = {
 	read: read,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 var storageName = 'storejs'

--- a/storages/sessionStorage.js
+++ b/storages/sessionStorage.js
@@ -7,7 +7,7 @@ module.exports = {
 	write: write,
 	each: each,
 	remove: remove,
-	clearAll: clearAll,
+	clearAll: clearAll
 }
 
 function sessionStorage() {


### PR DESCRIPTION
IE does not support the syntax of trailing commas in objects.

Resolves: #222