### PR TITLE
Fix a typo and correct arguments order

### DIFF
--- a/src/store-engine.js
+++ b/src/store-engine.js
@@ -113,7 +113,7 @@ var storeAPI = {
 	// namespace clones the current store and assigns it the given namespace
 	namespace: function(namespace) {
 		if (!this._legalNamespace.test(namespace)) {
-			throw new Error('store.js namespaces can only have alhpanumerics + underscores and dashes')
+			throw new Error('store.js namespaces can only have alphanumerics + underscores and dashes')
 		}
 		// create a prefix that is very unlikely to collide with un-namespaced keys
 		var namespacePrefix = '__storejs_'+namespace+'_'

--- a/src/util.js
+++ b/src/util.js
@@ -72,8 +72,8 @@ function slice(arr, index) {
 }
 
 function each(obj, fn) {
-	pluck(obj, function(key, val) {
-		fn(key, val)
+	pluck(obj, function(val, key) {
+		fn(val, key)
 		return false
 	})
 }


### PR DESCRIPTION
Both of these changes are cosmetic - fixing a typo in the error thrown from the `StoreAPI.namespace` function, and renaming the arguments in `util.each` to reflect the order that `util.pluck` sends them to its callback function.