### PR TITLE
Util function declaration compatible with "use strict"

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -27,7 +27,7 @@ function make_assign() {
 				each(Object(arguments[i]), function(val, key) {
 					obj[key] = val
 				})
-			}			
+			}
 			return obj
 		}
 	}
@@ -40,7 +40,7 @@ function make_create() {
 			return assign.apply(this, [Object.create(obj)].concat(assignArgsList))
 		}
 	} else {
-		function F() {} // eslint-disable-line no-inner-declarations
+		var F = function () {}
 		return function create(obj, assignProps1, assignProps2, etc) {
 			var assignArgsList = slice(arguments, 1)
 			F.prototype = obj


### PR DESCRIPTION
Make `make_assign` in `util.js` adhere to strict mode.

Newer versions of `UglifyJS` will fail to process this code, due to their recent commit https://github.com/mishoo/UglifyJS2/pull/2718/files#diff-9f97a9c36fbbfb0d19068d6fae3bb84eR904

Reported like this by Rollup upon uglify: `[!] (uglify plugin) Error: Error transforming bundle with 'uglify' plugin: In strict mode code, functions can only be declared at top level or immediately within another function.`

Builds successfully when using `var` which hoists the function like in this PR.