### PR TITLE
Add npm install instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ store.each(function(value, key) {
 
 Using npm:
 
+```sh
+npm i store
+```
+
 ```js
 // Example store.js usage with npm
 var store = require('store')


### PR DESCRIPTION
The name of the npm package isn't really clear, and people might install [storejs](https://www.npmjs.com/package/storejs) instead of store, because of the `README ` title.

I had to click on the npm version badge to be sure about the package name

Example of mistake: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/23269