### PR TITLE
Use the module key for the modern build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.12",
   "description": "A localStorage wrapper for all browsers without using cookies or flash. Uses localStorage, globalStorage, and userData behavior under the hood",
   "main": "dist/store.legacy.js",
+  "module": "dist/store.modern.js",
   "scripts": {
     "test": "make test"
   },


### PR DESCRIPTION
Possibly moderately breaking for someone using a modern build system for very old projects, but this would require less specific requiring for most people