### PR TITLE
docs: Fix simple typo, otherwse -> otherwise

### DIFF
--- a/storages/oldIE-userDataStorage.js
+++ b/storages/oldIE-userDataStorage.js
@@ -107,7 +107,7 @@ function _makeIEStorageElFunction() {
 		storageEl = storageOwner.createElement('div')
 	} catch(e) {
 		// somehow ActiveXObject instantiation failed (perhaps some special
-		// security settings or otherwse), fall back to per-path storage
+		// security settings or otherwise), fall back to per-path storage
 		storageEl = doc.createElement('div')
 		storageOwner = doc.body
 	}


### PR DESCRIPTION
There is a small typo in storages/oldIE-userDataStorage.js.

Should read `otherwise` rather than `otherwse`.

